### PR TITLE
refactor: Use a more engineering-oriented error code wrapper

### DIFF
--- a/app/favorite/cmd/main.go
+++ b/app/favorite/cmd/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"net"
 
 	"github.com/sirupsen/logrus"
@@ -36,11 +36,12 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if _, err := etcdRegister.Register(node, 10); err != nil {
-		panic(fmt.Sprintf("start service failed, err: %v", err))
+	if _, err = etcdRegister.Register(node, 10); err != nil {
+		logs.LogrusObj.Errorf("start service failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		logs.LogrusObj.Panicf("stack trace: \n%+v\n", err)
 	}
 	logrus.Info("service started listen on ", grpcAddress)
-	if err := server.Serve(lis); err != nil {
+	if err = server.Serve(lis); err != nil {
 		panic(err)
 	}
 }

--- a/app/favorite/internal/repository/db/dao/favorite.go
+++ b/app/favorite/internal/repository/db/dao/favorite.go
@@ -2,11 +2,11 @@ package dao
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"gorm.io/gorm"
 
 	favoritePb "github.com/CocaineCong/tangseng/idl/pb/favorite"
-	log "github.com/CocaineCong/tangseng/pkg/logger"
 	"github.com/CocaineCong/tangseng/repository/mysql/db"
 	"github.com/CocaineCong/tangseng/repository/mysql/model"
 )
@@ -23,7 +23,7 @@ func (dao *FavoriteDao) ListFavorite(req *favoritePb.FavoriteListReq) (r []*mode
 	err = dao.DB.Model(&model.Favorite{}).
 		Where("user_id = ?", req.UserId).Find(&r).Error
 	if err != nil {
-		return
+		return r, errors.Wrapf(err, "failed to query favorite list, userId = %v ", req.UserId)
 	}
 	return
 }
@@ -34,8 +34,7 @@ func (dao *FavoriteDao) CreateFavorite(req *favoritePb.FavoriteCreateReq) (err e
 		UserID:       req.UserId,
 	}
 	if err = dao.DB.Create(&favorite).Error; err != nil {
-		log.LogrusObj.Error("Insert Favorite Error:" + err.Error())
-		return
+		return errors.Wrapf(err, "failed to create favorite, userId = %v ", req.UserId)
 	}
 
 	return
@@ -44,7 +43,9 @@ func (dao *FavoriteDao) CreateFavorite(req *favoritePb.FavoriteCreateReq) (err e
 func (dao *FavoriteDao) DeleteFavorite(req *favoritePb.FavoriteDeleteReq) (err error) {
 	err = dao.DB.Where("favorite_id = ?", req.FavoriteId).
 		Delete(model.Favorite{}).Error
-
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete favorite, favoriteId = %v", req.FavoriteId)
+	}
 	return
 }
 
@@ -53,7 +54,7 @@ func (dao *FavoriteDao) UpdateFavorite(req *favoritePb.FavoriteUpdateReq) (err e
 	fMap["favorite_name"] = req.FavoriteName
 	err = dao.DB.Where("favorite_id = ?", req.FavoriteId).Updates(&fMap).Error
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to update favorite, favoriteId = %v ", req.FavoriteId)
 	}
 
 	return

--- a/app/favorite/internal/repository/db/dao/favortie_detail.go
+++ b/app/favorite/internal/repository/db/dao/favortie_detail.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"gorm.io/gorm"
 
@@ -23,7 +24,7 @@ func (dao *FavoriteDetailDao) CreateFavoriteDetail(req *favoritePb.FavoriteDetai
 	var f []*model.Favorite
 	err = dao.DB.Where("favorite_id = ?", req.FavoriteId).Find(&f).Error
 	if err != nil {
-		return
+		return errors.Wrapf(err, "failed to query favorite, favoriteId = %v ", req.FavoriteId)
 	}
 
 	fd := model.FavoriteDetail{
@@ -34,26 +35,42 @@ func (dao *FavoriteDetailDao) CreateFavoriteDetail(req *favoritePb.FavoriteDetai
 		Favorite: f,
 	}
 	err = dao.DB.Model(&model.FavoriteDetail{}).Create(&fd).Error
-
+	if err != nil {
+		return errors.Wrapf(err, "failed to create favoriteDetail，userID = %v,urlId = %v", req.UserId, req.UrlId)
+	}
 	return
 }
 
 func (dao *FavoriteDetailDao) ListFavoriteDetail(req *favoritePb.FavoriteDetailListReq) (r []*model.Favorite, err error) {
 	var f []*model.Favorite
-	dao.DB.Where("user_id = ?", req.UserId).Find(&f)
+	err = dao.DB.Where("user_id = ?", req.UserId).Find(&f).Error
+	if err != nil {
+		return r, errors.Wrapf(err, "failed to query favorite, userId = %v ", req.UserId)
+	}
 	for _, v := range f {
-		_ = dao.DB.Model(&v).Association("FavoriteDetail").Find(&v.FavoriteDetail)
+		err = dao.DB.Model(&v).Association("FavoriteDetail").Find(&v.FavoriteDetail)
 		r = append(r, v)
 	}
-
+	if err != nil {
+		err = errors.Wrapf(err, "failed to query favoriteDetail")
+	}
 	return
 }
 
-func (dao *FavoriteDetailDao) DeleteFavoriteDetail(req *favoritePb.FavoriteDetailDeleteReq) error {
+func (dao *FavoriteDetailDao) DeleteFavoriteDetail(req *favoritePb.FavoriteDetailDeleteReq) (err error) {
 	var f model.Favorite
 	var fd model.FavoriteDetail
-	dao.DB.Where("favorite_id = ?", req.FavoriteId).First(&f)
-	dao.DB.Where("favorite_detail_id = ?", req.FavoriteDetailId).First(&fd)
-	err := dao.DB.Model(&f).Association("FavoriteDetail").Delete(&fd)
-	return err
+	err = dao.DB.Where("favorite_id = ?", req.FavoriteId).First(&f).Error
+	if err != nil {
+		return errors.Wrapf(err, "failed to query favorite, favoriteId = %v ", req.FavoriteId)
+	}
+	err = dao.DB.Where("favorite_detail_id = ?", req.FavoriteDetailId).First(&fd).Error
+	if err != nil {
+		return errors.Wrapf(err, "failed to query favoriteDetail, favoriteDetailId = %v ", req.FavoriteDetailId)
+	}
+	err = dao.DB.Model(&f).Association("FavoriteDetail").Delete(&fd)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete favoriteDetail, favoriteDetailId = %v ", req.FavoriteDetailId)
+	}
+	return
 }

--- a/app/favorite/internal/service/favorite.go
+++ b/app/favorite/internal/service/favorite.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	"sync"
 
 	"github.com/CocaineCong/tangseng/app/favorite/internal/repository/db/dao"
@@ -29,6 +30,7 @@ func (s *FavoriteSrv) FavoriteCreate(ctx context.Context, req *pb.FavoriteCreate
 	resp.Code = e.SUCCESS
 	err = dao.NewFavoriteDao(ctx).CreateFavorite(req)
 	if err != nil {
+		err = errors.WithMessage(err, "dao.CreateFavorite error")
 		resp.Error = err.Error()
 		return
 	}
@@ -43,6 +45,7 @@ func (s *FavoriteSrv) FavoriteList(ctx context.Context, req *pb.FavoriteListReq)
 	resp.Code = e.SUCCESS
 	if err != nil {
 		resp.Code = e.ERROR
+		err = errors.WithMessage(err, "dao.ListFavorite error")
 		return
 	}
 	for i := range f {
@@ -61,12 +64,13 @@ func (s *FavoriteSrv) FavoriteUpdate(ctx context.Context, req *pb.FavoriteUpdate
 	err = dao.NewFavoriteDao(ctx).UpdateFavorite(req)
 	if err != nil {
 		resp.Code = e.ERROR
+		err = errors.WithMessage(err, "dao.UpdateFavorite error")
 		resp.Error = err.Error()
 		return
 	}
 
 	resp.Msg = e.GetMsg(int(resp.Code))
-	return resp, nil
+	return
 }
 
 func (s *FavoriteSrv) FavoriteDelete(ctx context.Context, req *pb.FavoriteDeleteReq) (resp *pb.FavoriteCommonResponse, err error) {
@@ -75,6 +79,7 @@ func (s *FavoriteSrv) FavoriteDelete(ctx context.Context, req *pb.FavoriteDelete
 	err = dao.NewFavoriteDao(ctx).DeleteFavorite(req)
 	if err != nil {
 		resp.Code = e.ERROR
+		err = errors.WithMessage(err, "dao.DeleteFavorite error")
 		resp.Error = err.Error()
 		return
 	}
@@ -89,6 +94,7 @@ func (s *FavoriteSrv) FavoriteDetailCreate(ctx context.Context, req *pb.Favorite
 	err = dao.NewFavoriteDetailDao(ctx).CreateFavoriteDetail(req)
 	if err != nil {
 		resp.Code = e.ERROR
+		err = errors.WithMessage(err, "dao.CreateFavoriteDetail error")
 		resp.Error = err.Error()
 		return
 	}
@@ -102,6 +108,7 @@ func (s *FavoriteSrv) FavoriteDetailDelete(ctx context.Context, req *pb.Favorite
 	err = dao.NewFavoriteDetailDao(ctx).DeleteFavoriteDetail(req)
 	if err != nil {
 		resp.Code = e.ERROR
+		err = errors.WithMessage(err, "dao.DeleteFavoriteDetail error")
 		resp.Error = err.Error()
 		return
 	}
@@ -116,6 +123,7 @@ func (s *FavoriteSrv) FavoriteDetailList(ctx context.Context, req *pb.FavoriteDe
 	fdResp, err := dao.NewFavoriteDetailDao(ctx).ListFavoriteDetail(req)
 	if err != nil {
 		resp.Code = e.ERROR
+		err = errors.WithMessage(err, "dao.ListFavoriteDetail error")
 		return
 	}
 

--- a/app/gateway/http/favorites.go
+++ b/app/gateway/http/favorites.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -20,14 +21,16 @@ func ListFavorite(ctx *gin.Context) {
 	}
 	user, err := ctl.GetUserInfo(ctx.Request.Context())
 	if err != nil {
-		log.LogrusObj.Errorf("GetUserInfo:%v", err)
+		log.LogrusObj.Errorf("ctl.GetUserInfo failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "获取用户信息错误"))
 		return
 	}
 	req.UserId = user.Id
 	r, err := rpc.FavoriteList(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("FavoriteList:%v", err)
+		log.LogrusObj.Errorf("rpc.FavoriteList failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "FavoriteList RPC服务调用错误"))
 		return
 	}
@@ -44,14 +47,16 @@ func CreateFavorite(ctx *gin.Context) {
 	}
 	user, err := ctl.GetUserInfo(ctx.Request.Context())
 	if err != nil {
-		log.LogrusObj.Errorf("GetUserInfo:%v", err)
+		log.LogrusObj.Errorf("ctl.GetUserInfo failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "获取用户信息错误"))
 		return
 	}
 	req.UserId = user.Id
 	r, err := rpc.FavoriteCreate(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("FavoriteCreate:%v", err)
+		log.LogrusObj.Errorf("rpc.FavoriteCreate failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "FavoriteCreateReq RPC服务调用错误"))
 		return
 	}
@@ -68,14 +73,16 @@ func UpdateFavorite(ctx *gin.Context) {
 	}
 	user, err := ctl.GetUserInfo(ctx.Request.Context())
 	if err != nil {
-		log.LogrusObj.Errorf("GetUserInfo:%v", err)
+		log.LogrusObj.Errorf("ctl.GetUserInfo failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "获取用户信息错误"))
 		return
 	}
 	req.UserId = user.Id
 	r, err := rpc.FavoriteCreate(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("FavoriteCreate:%v", err)
+		log.LogrusObj.Errorf("rpc.FavoriteCreate failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "UpdateFavorite RPC服务调用错误"))
 		return
 	}
@@ -92,14 +99,16 @@ func DeleteFavorite(ctx *gin.Context) {
 	}
 	user, err := ctl.GetUserInfo(ctx.Request.Context())
 	if err != nil {
-		log.LogrusObj.Errorf("GetUserInfo:%v", err)
+		log.LogrusObj.Errorf("ctl.GetUserInfo failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "获取用户信息错误"))
 		return
 	}
 	req.UserId = user.Id
 	r, err := rpc.FavoriteDelete(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("FavoriteDelete:%v", err)
+		log.LogrusObj.Errorf("rpc.FavoriteDelete failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "DeleteFavorite RPC服务调用错误"))
 		return
 	}
@@ -116,14 +125,16 @@ func ListFavoriteDetail(ctx *gin.Context) {
 	}
 	user, err := ctl.GetUserInfo(ctx.Request.Context())
 	if err != nil {
-		log.LogrusObj.Errorf("GetUserInfo:%v", err)
+		log.LogrusObj.Errorf("ctl.GetUserInfo failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "获取用户信息错误"))
 		return
 	}
 	req.UserId = user.Id
 	r, err := rpc.FavoriteDetailList(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("FavoriteDetailList:%v", err)
+		log.LogrusObj.Errorf("rpc.FavoriteDetailList failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "FavoriteDetailList RPC服务调用错误"))
 		return
 	}
@@ -140,14 +151,16 @@ func CreateFavoriteDetail(ctx *gin.Context) {
 	}
 	user, err := ctl.GetUserInfo(ctx.Request.Context())
 	if err != nil {
-		log.LogrusObj.Errorf("GetUserInfo:%v", err)
+		log.LogrusObj.Errorf("ctl.GetUserInfo failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "获取用户信息错误"))
 		return
 	}
 	req.UserId = user.Id
 	r, err := rpc.FavoriteDetailCreate(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("FavoriteDetailCreate:%v", err)
+		log.LogrusObj.Errorf("rpc.FavoriteDetailCreate failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "FavoriteDetailCreate RPC服务调用错误"))
 		return
 	}
@@ -164,14 +177,16 @@ func DeleteFavoriteDetail(ctx *gin.Context) {
 	}
 	user, err := ctl.GetUserInfo(ctx.Request.Context())
 	if err != nil {
-		log.LogrusObj.Errorf("GetUserInfo:%v", err)
+		log.LogrusObj.Errorf("ctl.GetUserInfo failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "获取用户信息错误"))
 		return
 	}
 	req.UserId = user.Id
 	r, err := rpc.FavoriteDetailDelete(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("FavoriteDetailDelete:%v", err)
+		log.LogrusObj.Errorf("rpc.FavoriteDetailDelete failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "FavoriteDetailDelete RPC服务调用错误"))
 		return
 	}

--- a/app/gateway/http/index_platform.go
+++ b/app/gateway/http/index_platform.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -21,7 +22,8 @@ func BuildIndexByFiles(ctx *gin.Context) {
 
 	r, err := rpc.BuildIndex(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("BuildIndexByFiles:%v", err)
+		log.LogrusObj.Errorf("rpc.BuildIndex failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "BuildIndexByFiles RPC服务调用错误"))
 		return
 	}

--- a/app/gateway/http/search_engine.go
+++ b/app/gateway/http/search_engine.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -22,7 +23,8 @@ func SearchEngineSearch(ctx *gin.Context) {
 
 	r, err := rpc.SearchEngineSearch(ctx, req)
 	if err != nil {
-		log.LogrusObj.Errorf("SearchEngineSearch:%v", err)
+		log.LogrusObj.Errorf("rpc.SearchEngineSearch failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "SearchEngineSearch RPC服务调用错误"))
 		return
 	}
@@ -41,7 +43,8 @@ func WordAssociation(ctx *gin.Context) {
 
 	r, err := rpc.WordAssociation(ctx, req)
 	if err != nil {
-		log.LogrusObj.Errorf("WordAssociation:%v", err)
+		log.LogrusObj.Errorf("rpc.WordAssociation failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "WordAssociation RPC服务调用错误"))
 		return
 	}

--- a/app/gateway/http/search_vector.go
+++ b/app/gateway/http/search_vector.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -22,7 +23,8 @@ func SearchVector(ctx *gin.Context) {
 
 	r, err := rpc.SearchVector(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("SearchVector:%v", err)
+		log.LogrusObj.Errorf("rpc.SearchVector failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "SearchVector RPC服务调用错误"))
 		return
 	}

--- a/app/gateway/http/user.go
+++ b/app/gateway/http/user.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -23,7 +24,8 @@ func UserRegister(ctx *gin.Context) {
 	}
 	r, err := rpc.UserRegister(ctx, &userReq)
 	if err != nil {
-		log.LogrusObj.Errorf("UserRegister:%v", err)
+		log.LogrusObj.Errorf("rpc.UserRegister failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "UserRegister RPC服务调用错误"))
 		return
 	}
@@ -42,14 +44,16 @@ func UserLogin(ctx *gin.Context) {
 
 	userResp, err := rpc.UserLogin(ctx, &req)
 	if err != nil {
-		log.LogrusObj.Errorf("RPC UserLogin:%v", err)
+		log.LogrusObj.Errorf("rpc.UserLogin failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "UserLogin RPC服务调用错误"))
 		return
 	}
 
 	aToken, rToken, err := jwt.GenerateToken(userResp.UserDetail.UserId, userResp.UserDetail.UserName)
 	if err != nil {
-		log.LogrusObj.Errorf("RPC GenerateToken:%v", err)
+		log.LogrusObj.Errorf("jwt.GenerateToken failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		log.LogrusObj.Errorf("stack trace: \n%+v\n", err)
 		ctx.JSON(http.StatusOK, ctl.RespError(ctx, err, "加密错误"))
 		return
 	}

--- a/app/gateway/rpc/favorite.go
+++ b/app/gateway/rpc/favorite.go
@@ -2,7 +2,7 @@ package rpc
 
 import (
 	"context"
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/CocaineCong/tangseng/consts/e"
 	favoritePb "github.com/CocaineCong/tangseng/idl/pb/favorite"
@@ -11,10 +11,11 @@ import (
 func FavoriteCreate(ctx context.Context, req *favoritePb.FavoriteCreateReq) (resp *favoritePb.FavoriteCommonResponse, err error) {
 	resp, err = FavoriteClient.FavoriteCreate(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "FavoriteClient.FavoriteCreate error")
 		return
 	}
 	if resp.Code != e.SUCCESS {
-		err = errors.New(resp.Error)
+		err = errors.Wrap(errors.New(resp.Error), "resp.Code is not success")
 		return
 	}
 
@@ -24,11 +25,12 @@ func FavoriteCreate(ctx context.Context, req *favoritePb.FavoriteCreateReq) (res
 func FavoriteUpdate(ctx context.Context, req *favoritePb.FavoriteUpdateReq) (resp *favoritePb.FavoriteCommonResponse, err error) {
 	resp, err = FavoriteClient.FavoriteUpdate(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "FavoriteClient.FavoriteUpdate error")
 		return
 	}
 
 	if resp.Code != e.SUCCESS {
-		err = errors.New(resp.Error)
+		err = errors.Wrap(errors.New(resp.Error), "resp.Code is not success")
 		return
 	}
 
@@ -38,10 +40,11 @@ func FavoriteUpdate(ctx context.Context, req *favoritePb.FavoriteUpdateReq) (res
 func FavoriteList(ctx context.Context, req *favoritePb.FavoriteListReq) (resp *favoritePb.FavoriteListResponse, err error) {
 	resp, err = FavoriteClient.FavoriteList(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "FavoriteClient.FavoriteList error")
 		return
 	}
 	if resp.Code != e.SUCCESS {
-		err = errors.New("FavoriteList 出现错误") // TODO 整个错误 proto
+		err = errors.Wrap(errors.New("FavoriteList 出现错误"), "resp.Code is not success") // TODO 整个错误 proto
 		return
 	}
 
@@ -51,10 +54,11 @@ func FavoriteList(ctx context.Context, req *favoritePb.FavoriteListReq) (resp *f
 func FavoriteDelete(ctx context.Context, req *favoritePb.FavoriteDeleteReq) (resp *favoritePb.FavoriteCommonResponse, err error) {
 	resp, err = FavoriteClient.FavoriteDelete(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "FavoriteClient.FavoriteDelete error")
 		return
 	}
 	if resp.Code != e.SUCCESS {
-		err = errors.New(resp.Error)
+		err = errors.Wrap(errors.New(resp.Error), "resp.Code is not success")
 		return
 	}
 
@@ -64,10 +68,11 @@ func FavoriteDelete(ctx context.Context, req *favoritePb.FavoriteDeleteReq) (res
 func FavoriteDetailList(ctx context.Context, req *favoritePb.FavoriteDetailListReq) (resp *favoritePb.FavoriteDetailListResponse, err error) {
 	resp, err = FavoriteClient.FavoriteDetailList(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "FavoriteClient.FavoriteDetailList error")
 		return
 	}
 	if resp.Code != e.SUCCESS {
-		err = errors.New("出现错误")
+		err = errors.Wrap(errors.New("出现错误"), "resp.Code is not success")
 		return
 	}
 
@@ -77,10 +82,11 @@ func FavoriteDetailList(ctx context.Context, req *favoritePb.FavoriteDetailListR
 func FavoriteDetailDelete(ctx context.Context, req *favoritePb.FavoriteDetailDeleteReq) (resp *favoritePb.FavoriteCommonResponse, err error) {
 	resp, err = FavoriteClient.FavoriteDetailDelete(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "FavoriteClient.FavoriteDetailDelete error")
 		return
 	}
 	if resp.Code != e.SUCCESS {
-		err = errors.New(resp.Error)
+		err = errors.Wrap(errors.New(resp.Error), "resp.Code is not success")
 		return
 	}
 
@@ -90,10 +96,11 @@ func FavoriteDetailDelete(ctx context.Context, req *favoritePb.FavoriteDetailDel
 func FavoriteDetailCreate(ctx context.Context, req *favoritePb.FavoriteDetailCreateReq) (resp *favoritePb.FavoriteCommonResponse, err error) {
 	resp, err = FavoriteClient.FavoriteDetailCreate(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "FavoriteClient.FavoriteDetailCreate error")
 		return
 	}
 	if resp.Code != e.SUCCESS {
-		err = errors.New(resp.Error)
+		err = errors.Wrap(errors.New(resp.Error), "resp.Code is not success")
 		return
 	}
 

--- a/app/gateway/rpc/index_platform.go
+++ b/app/gateway/rpc/index_platform.go
@@ -2,16 +2,16 @@ package rpc
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	pb "github.com/CocaineCong/tangseng/idl/pb/index_platform"
-	log "github.com/CocaineCong/tangseng/pkg/logger"
 )
 
 // BuildIndex 建立索引的RPC调用
 func BuildIndex(ctx context.Context, req *pb.BuildIndexReq) (resp *pb.BuildIndexResp, err error) {
 	resp, err = IndexPlatformClient.BuildIndexService(ctx, req)
 	if err != nil {
-		log.LogrusObj.Error("BuildIndex-BuildIndexService", err)
+		err = errors.WithMessage(err, "IndexPlatformClient.BuildIndexService err")
 		return
 	}
 

--- a/app/gateway/rpc/init.go
+++ b/app/gateway/rpc/init.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"time"
 
@@ -84,5 +85,6 @@ func connectServer(serviceName string) (conn *grpc.ClientConn, err error) {
 	}
 
 	conn, err = grpc.DialContext(ctx, addr, opts...)
+	err = errors.Wrapf(err, "failed to connect to gRPC service,address is %v", addr)
 	return
 }

--- a/app/gateway/rpc/search_engine.go
+++ b/app/gateway/rpc/search_engine.go
@@ -2,7 +2,7 @@ package rpc
 
 import (
 	"context"
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/CocaineCong/tangseng/consts/e"
 	pb "github.com/CocaineCong/tangseng/idl/pb/search_engine"
@@ -11,11 +11,12 @@ import (
 func SearchEngineSearch(ctx context.Context, req *pb.SearchEngineRequest) (r *pb.SearchEngineResponse, err error) {
 	r, err = SearchEngineClient.SearchEngineSearch(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "SearchEngineClient.SearchEngineSearch error")
 		return
 	}
 
 	if r.Code != e.SUCCESS {
-		err = errors.New(r.Msg)
+		err = errors.Wrap(errors.New(r.Msg), "r.Code is unsuccessful")
 		return
 	}
 
@@ -25,11 +26,12 @@ func SearchEngineSearch(ctx context.Context, req *pb.SearchEngineRequest) (r *pb
 func WordAssociation(ctx context.Context, req *pb.SearchEngineRequest) (r *pb.WordAssociationResponse, err error) {
 	r, err = SearchEngineClient.WordAssociation(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "SearchEngineClient.WordAssociation error")
 		return
 	}
 
 	if r.Code != e.SUCCESS {
-		err = errors.New(r.Msg)
+		err = errors.Wrap(errors.New(r.Msg), "r.Code is unsuccessful")
 		return
 	}
 

--- a/app/gateway/rpc/search_vector.go
+++ b/app/gateway/rpc/search_vector.go
@@ -2,7 +2,7 @@ package rpc
 
 import (
 	"context"
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/CocaineCong/tangseng/consts/e"
 	pb "github.com/CocaineCong/tangseng/idl/pb/search_vector"
@@ -11,11 +11,12 @@ import (
 func SearchVector(ctx context.Context, req *pb.SearchVectorRequest) (resp *pb.SearchVectorResponse, err error) {
 	resp, err = SearchVectorClient.SearchVector(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "SearchEngineClient.SearchVector error")
 		return
 	}
 
 	if resp.Code != e.SUCCESS {
-		err = errors.New(resp.Msg)
+		err = errors.Wrap(errors.New(resp.Msg), "resp.Code is unsuccessful")
 		return
 	}
 

--- a/app/gateway/rpc/user.go
+++ b/app/gateway/rpc/user.go
@@ -2,7 +2,7 @@ package rpc
 
 import (
 	"context"
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/CocaineCong/tangseng/consts/e"
 	userPb "github.com/CocaineCong/tangseng/idl/pb/user"
@@ -11,11 +11,12 @@ import (
 func UserLogin(ctx context.Context, req *userPb.UserLoginReq) (resp *userPb.UserDetailResponse, err error) {
 	r, err := UserClient.UserLogin(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "UserClient.UserLogin error")
 		return
 	}
 
 	if r.Code != e.SUCCESS {
-		err = errors.New("登陆失败")
+		err = errors.Wrap(errors.New("登陆失败"), "r.Code is unsuccessful")
 		return
 	}
 
@@ -25,11 +26,12 @@ func UserLogin(ctx context.Context, req *userPb.UserLoginReq) (resp *userPb.User
 func UserRegister(ctx context.Context, req *userPb.UserRegisterReq) (resp *userPb.UserCommonResponse, err error) {
 	r, err := UserClient.UserRegister(ctx, req)
 	if err != nil {
+		err = errors.WithMessage(err, "UserClient.UserRegister error")
 		return
 	}
 
 	if r.Code != e.SUCCESS {
-		err = errors.New(r.Msg)
+		err = errors.Wrap(errors.New(r.Msg), "r.Code is unsuccessful")
 		return
 	}
 

--- a/app/user/cmd/main.go
+++ b/app/user/cmd/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"fmt"
+	logs "github.com/CocaineCong/tangseng/pkg/logger"
+	"github.com/pkg/errors"
 	"net"
 
 	"github.com/sirupsen/logrus"
@@ -36,7 +37,8 @@ func main() {
 		panic(err)
 	}
 	if _, err := etcdRegister.Register(userNode, 10); err != nil {
-		panic(fmt.Sprintf("start service failed, err: %v", err))
+		logs.LogrusObj.Errorf("start service failed, original error: %T %v", errors.Cause(err), errors.Cause(err))
+		logs.LogrusObj.Panicf("stack trace: \n%+v\n", err)
 	}
 	logrus.Info("service started listen on ", grpcAddress)
 	if err := server.Serve(lis); err != nil {

--- a/app/user/internal/service/user.go
+++ b/app/user/internal/service/user.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	"sync"
 
 	"github.com/CocaineCong/tangseng/app/user/internal/repository/db/dao"
@@ -29,6 +30,7 @@ func (u *UserSrv) UserLogin(ctx context.Context, req *pb.UserLoginReq) (resp *pb
 	r, err := dao.NewUserDao(ctx).GetUserInfo(req)
 	if err != nil {
 		resp.Code = e2.ERROR
+		err = errors.WithMessage(err, "getUserInfo error")
 		return
 	}
 	resp.UserDetail = &pb.UserResp{
@@ -45,6 +47,7 @@ func (u *UserSrv) UserRegister(ctx context.Context, req *pb.UserRegisterReq) (re
 	err = dao.NewUserDao(ctx).CreateUser(req)
 	if err != nil {
 		resp.Code = e2.ERROR
+		err = errors.WithMessage(err, "createUser error")
 		return
 	}
 	resp.Data = e2.GetMsg(int(resp.Code))


### PR DESCRIPTION
I change the files in ./app/favorite,gateway,user. Use "github.com/pkg/errors" to wrap error. In a word, If a function doesn't need to return an error, print the error and stack information with logrus, otherwise wrap the error and append some information.