### PR TITLE
feature:support hot reloading through a multi-version InvertedDB. 

### DIFF
--- a/app/search_engine/repository/storage/inverted_db_test.go
+++ b/app/search_engine/repository/storage/inverted_db_test.go
@@ -20,7 +20,9 @@ package storage
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/CocaineCong/tangseng/config"
 )
@@ -37,10 +39,67 @@ func TestGetInvertedInfo(t *testing.T) {
 	fmt.Println(p)
 }
 
+// 为redisMockChan产生文件名
+func getMsg(testDir string, start, end int) []string {
+	msg := make([]string, 0)
+	for file_id := start; file_id < end; file_id++ {
+		msg = append(msg, testDir+fmt.Sprintf("%d", file_id))
+	}
+	return msg
+}
+
 func TestInitInvertedDB(t *testing.T) {
+	testDir := "/tmp/ts/TestInvertedDBManager/"
+	err := os.MkdirAll(testDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+	defer os.RemoveAll(testDir) // 确保在测试结束时删除目录
+	mockRedisChan := make(chan []string, 10)
 	ctx := context.Background()
+	ctx = context.WithValue(ctx, "cleanTime", 2)
+	ctx = context.WithValue(ctx, "mockRedisChan", mockRedisChan)
+
+	// 向channel发送数据
+	mockRedisChan <- getMsg(testDir, 3, 10)
+
 	InitInvertedDB(ctx)
-	for _, v := range GlobalInvertedDB {
-		fmt.Println(v)
+
+	//睡眠3秒，确保后台clean线程删除version-0
+	time.Sleep(3 * time.Second)
+	if len(GlobalInvertedDB.versionSet) != 1 {
+		t.Errorf("Expected %v, but got %v", 1, len(GlobalInvertedDB.versionSet))
+	}
+	if GlobalInvertedDB.currentVersion.versionId != 1 {
+		t.Errorf("Expected %v, but got %v", 1, GlobalInvertedDB.currentVersion.versionId)
+	}
+	// 使用当前版本，然后新建一个版本
+	_, oldversionId := GlobalInvertedDB.Ref()
+	if GlobalInvertedDB.currentVersion.ref.Load() != 1 {
+		t.Errorf("Expected %v, but got %v", 1, GlobalInvertedDB.currentVersion.ref.Load())
+	}
+	mockRedisChan <- getMsg(testDir, 6, 12)
+	GlobalInvertedDB.UpdateFromRedis(ctx)
+	
+	/*
+	   此时有两个version
+	                                   current ↓
+	       | version-1,ref:1 | version-2,ref:0 |
+	*/
+	if GlobalInvertedDB.currentVersion.versionId != 2 {
+		t.Errorf("Expected %v, but got %v", 1, GlobalInvertedDB.currentVersion.versionId)
+	}
+
+	//去引用，这个版本会被异步释放掉
+	GlobalInvertedDB.Unref(oldversionId)
+
+	//睡眠3秒，确保后台clean线程删除version-1
+	time.Sleep(3 * time.Second)
+	// 当前只有最新版本
+	if GlobalInvertedDB.currentVersion.versionId != 2 {
+		t.Errorf("Expected %v, but got %v", 1, GlobalInvertedDB.currentVersion.versionId)
+	}
+	if len(GlobalInvertedDB.versionSet) != 1 {
+		t.Errorf("Expected %v, but got %v", 1, len(GlobalInvertedDB.versionSet))
 	}
 }

--- a/app/search_engine/service/recall/recall.go
+++ b/app/search_engine/service/recall/recall.go
@@ -188,7 +188,9 @@ func (r *Recall) searchDoc(ctx context.Context, tokens []string) (recalls []int6
 func fetchPostingsByToken(token string) (postingsList []*types.PostingsList, err error) {
 	// 遍历存储index的地方，token对应的doc Id 全部取出
 	postingsList = make([]*types.PostingsList, 0, 1e6)
-	for _, inverted := range storage.GlobalInvertedDB {
+	dbs, versionId := storage.GlobalInvertedDB.Ref()
+	defer storage.GlobalInvertedDB.Unref(versionId)
+	for _, inverted := range dbs {
 		docIds, errx := inverted.GetInverted([]byte(token))
 		if errx != nil {
 			err = errors.WithMessage(err, "getInverted error")


### PR DESCRIPTION
## feature
 issue：#51 
Support hot reloading by **multi-version** InvertedDB. 
Specifically, each request to InvertedDB logs a version number, and each time a new index is loaded, a new version is created. 
The data from outdated versions is then released asynchronously.
``` go
// Manager -> versionSet:
// 	                   current ↓
// | version-1,ref:1 | version-2,ref:0 |

type Version struct {
	versionId int64 // version id, unique
	dbTable   map[string]*InvertedDB // InvertedDB  held by this version is mapped by file
	oldFiles  []string               // Files that are obsolete for the next version
	dbs       []*InvertedDB
	ref       atomic.Int64
}

Expose：
func (m *InvertedDBManager) Ref() ([]*InvertedDB, int64)
func (m *InvertedDBManager) Unref(versionId int64)
func (m *InvertedDBManager) UpdateFromRedis(ctx context.Context)
```

To reduce interference on the critical write path for online requests, we build versions not-in-place, minimizing the time spent on write operations.
## usage
```go
dbs, versionId := storage.GlobalInvertedDB.Ref()
defer storage.GlobalInvertedDB.Unref(versionId)
for _, inverted := range dbs {
// you code here...
}
```
##  test
mock redis chan in `repository/redis/inverted_index_test.go`